### PR TITLE
Update AbstractQuery.php

### DIFF
--- a/src/Core/Migration/AbstractQuery.php
+++ b/src/Core/Migration/AbstractQuery.php
@@ -219,7 +219,7 @@ abstract class AbstractQuery
      */
     protected static function _columnExists($sTable, $sColumn)
     {
-        $oConfig = oxRegistry::getConfig();
+        $oConfig = Registry::getConfig();
         $sDbName = $oConfig->getConfigParam('dbName');
         $sSql = 'SELECT 1
                     FROM information_schema.COLUMNS


### PR DESCRIPTION
Fix  fatal error in \OxidProfessionalServices\OxidConsole\Core\Migration\AbstractQuery::_columnExists -  `Registry` usage.