### PR TITLE
added support for adding commands from composer packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog for OXID Console
 
+## [v5.1.0]
+### Added
+- Support for commands registered via composer.json of other composer packages  
+
+## [v5.0.29]
+### Changed
+- Fix error during migrations which where using _columnExists
+
 ## [v5.0.28]
 ### Changed
 -  fix:states command: modules without meta data version can be fixed. 


### PR DESCRIPTION
the new oxid core console (https://github.com/OXID-eSales/oxideshop_ce/tree/b-6.x-introduce_console-OXDEV-1580) will also support collecting comands this way and so will oxrun (https://github.com/OXIDprojects/oxrun). By adding this functionality commands can be written and used independently of the console implementation 