### PR TITLE
Add active state condition befor adding controllers to database:

### DIFF
--- a/src/Core/Module/ModuleStateFixer.php
+++ b/src/Core/Module/ModuleStateFixer.php
@@ -327,34 +327,35 @@ class ModuleStateFixer extends ModuleInstaller
         }
     }
 
-
     /**
      * Add controllers map for a given module Id to config
      *
      * @param array  $moduleControllers Map of controller ids and class names
      * @param string $moduleId          The Id of the module
+     * @param Module $module            Module core class
      */
     protected function setModuleControllers($moduleControllers, $moduleId, $module)
     {
-        $classProviderStorage = $this->getClassProviderStorage();
-        $dbMap = $classProviderStorage->get();
 
-        $controllersForThatModuleInDb = isset($dbMap[$moduleId]) ? $dbMap[$moduleId] : [];
-
-        $duplicatedKeys = array_intersect_key(array_change_key_case($moduleControllers, CASE_LOWER), $controllersForThatModuleInDb);
-
-        if (array_diff_assoc($moduleControllers,$duplicatedKeys)) {
-            $this->output->writeLn("$moduleId fix module ModuleControllers");
-            $this->deleteModuleControllers($moduleId);
-            $this->resetModuleCache($module);
-            $this->validateModuleMetadataControllersOnActivation($moduleControllers);
-
+        if ($module->isActive()) {
             $classProviderStorage = $this->getClassProviderStorage();
+            $dbMap = $classProviderStorage->get();
+            $controllersForThatModuleInDb = isset($dbMap[$moduleId]) ? $dbMap[$moduleId] : [];
+            $duplicatedKeys = array_intersect_key(
+                array_change_key_case($moduleControllers, CASE_LOWER), $controllersForThatModuleInDb
+            );
+            if (array_diff_assoc($moduleControllers, $duplicatedKeys)) {
+                $this->output->writeLn("$moduleId fix module ModuleControllers");
+                $this->deleteModuleControllers($moduleId);
+                $this->resetModuleCache($module);
+                $this->validateModuleMetadataControllersOnActivation($moduleControllers);
 
-            $classProviderStorage->add($moduleId, $moduleControllers);
-            $this->needCacheClear = true;
+                $classProviderStorage = $this->getClassProviderStorage();
+
+                $classProviderStorage->add($moduleId, $moduleControllers);
+                $this->needCacheClear = true;
+            }
         }
-
     }
 
 

--- a/src/Core/Module/ModuleStateFixer.php
+++ b/src/Core/Module/ModuleStateFixer.php
@@ -355,7 +355,10 @@ class ModuleStateFixer extends ModuleInstaller
                 $classProviderStorage->add($moduleId, $moduleControllers);
                 $this->needCacheClear = true;
             }
-        }
+        } else {
+            $moduleCache = oxNew( \OxidEsales\Eshop\Core\Module\ModuleCache::class, $module);
+            $moduleInstaller = oxNew(\OxidEsales\Eshop\Core\Module\ModuleInstaller::class, $moduleCache);
+            $moduleInstaller->deactivate($module);}
     }
 
 


### PR DESCRIPTION
When fixing modules that has metadata Version > 2 and define controllers, this controllers are added to aModulesControllers in oxconfig.
This behavior is correct for active modules but when adding controllers for inactive modules, than activating it lead to an exception, as such controllers are already configured. In a second step activation works.

Steps to reproduce:
Set up shop including oxid console.
Test activation/deactivation for paypal
Run ```php vendor/bin/oxid modules:fix --all``` from installation path
Try to activate paypal module again.

BTW, changes looks strange but simple surround code with if($module->isActive()){}