### PR TITLE
Make console work with broken config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for OXID Console
 
+## [v5.3.0]
+### Changed
+- Console runs even if shop has a broken configuration
+- Version is read by composers installed.json
+
 ## [v5.2.0]
 ### Added
 - Support for commands registered via services.yaml of other composer packages  

--- a/bin/oxid
+++ b/bin/oxid
@@ -43,6 +43,19 @@ try {
 
     loadBootstrap();
 
+    $oConfig = \OxidEsales\Eshop\Core\Registry::getConfig();
+    $aLanguages = $oConfig->getConfigParam('aLanguages');
+    $aLanguageParams = $oConfig->getConfigParam('aLanguageParams');
+
+    if (false === $aLanguagesParams) {
+        echo 'Config Param for aLanguagesParams is broken. Setting default Values to de';
+        $oConfig->saveShopConfVar('aarr', 'aLanguageParams', ['de' => ['baseId' => 0 , 'active' => 1 , 'sort' => 1]]);
+    }
+    if (false === $aLanguages) {
+        echo 'Config Param for aLanguages is broken. Setting default Values to de';
+        $oConfig->saveShopConfVar('aarr', 'aLanguages', ['de' => 'Deutsch']);
+    }
+
     $v = new VersionHelper;
     $version = $v->getVersion('oxid-professional-services/oxid-console');
 

--- a/src/Command/GenerateModuleCommand.php
+++ b/src/Command/GenerateModuleCommand.php
@@ -52,7 +52,6 @@ class GenerateModuleCommand extends Command
             ->setAliases(['g:module'])
             ->setDescription('Generate new module scaffold');
 
-        $this->init();
     }
 
     private function init()
@@ -69,6 +68,7 @@ class GenerateModuleCommand extends Command
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->init();
         $this->input = $input;
         $this->output = $output;
 

--- a/src/Core/CommandCollector.php
+++ b/src/Core/CommandCollector.php
@@ -135,9 +135,15 @@ class CommandCollector
         if (! class_exists(ModuleList::class)) {
             print "ERROR: Oxid ModuleList class can not be loaded, please run vendor/bin/oe-eshop-unified_namespace_generator";
         } else {
-            $moduleList = oxNew(ModuleList::class);
-            $modulesDir = $oConfig->getModulesDir();
-            $moduleList->getModulesFromDir($modulesDir);
+            try {
+                $moduleList = oxNew(ModuleList::class);
+                $modulesDir = $oConfig->getModulesDir();
+                $moduleList->getModulesFromDir($modulesDir);
+            } catch (\Throwable $exception) {
+                print "Shop is not able to list modules\n";
+                print $exception->getMessage();
+                return [];
+            }
         }
 
         $paths = $this->getPathsOfAvailableModules();

--- a/src/Core/Composer/VersionHelper.php
+++ b/src/Core/Composer/VersionHelper.php
@@ -24,11 +24,9 @@ class VersionHelper {
     {
         $fullPath = __FILE__;
         $vendorDir = dirname(dirname(dirname(dirname(dirname(dirname($fullPath))))));
-        $rootDir = dirname($vendorDir);
-        $fileName = $rootDir . '/composer.lock';
+        $fileName = $vendorDir . '/composer/installed.json';
         $content = file_get_contents($fileName);
-        $content = json_decode($content, true);
-        $packages = $content['packages'];
+        $packages = json_decode($content, true);
         $version = null;
         foreach ($packages as $package) {
             if ($package['name'] == $packageName) {


### PR DESCRIPTION
If for any reason the shop config is broken, the console tries to keep running so you can make use of commands to repair the shop 