### PR TITLE
oxdi 6.2 - Fix rc command

### DIFF
--- a/src/Core/CommandCollector.php
+++ b/src/Core/CommandCollector.php
@@ -112,7 +112,12 @@ class CommandCollector
         foreach ($symfonyContainer->findTaggedServiceIds('console.command') as $id => $tags) {
             $definition = $symfonyContainer->getDefinition($id);
             $class = $definition->getClass();
-            $commandsClasses[] = new $class;
+            try{
+                //TODO maybe get the command with DI container
+                $commandsClasses[] = new $class;
+            } catch($ex) {
+                print "WARNING: can not create command $id " . $ex->getMessage();                
+            }
         }
 
         return $commandsClasses;

--- a/src/Core/CommandCollector.php
+++ b/src/Core/CommandCollector.php
@@ -115,7 +115,7 @@ class CommandCollector
             try{
                 //TODO maybe get the command with DI container
                 $commandsClasses[] = new $class;
-            } catch(\Exception $ex) {
+            } catch(\Throwable $ex) {
                 print "WARNING: can not create command $id " . $ex->getMessage();                
             }
         }

--- a/src/Core/CommandCollector.php
+++ b/src/Core/CommandCollector.php
@@ -115,7 +115,7 @@ class CommandCollector
             try{
                 //TODO maybe get the command with DI container
                 $commandsClasses[] = new $class;
-            } catch($ex) {
+            } catch(\Exception $ex) {
                 print "WARNING: can not create command $id " . $ex->getMessage();                
             }
         }


### PR DESCRIPTION
this is a workaround for collecting commands in oxid 6.2

oxid 6.2 offers DI and command could be fetched from that, but the console does not yet use it and tries to create instance by itself which fails if the command constructor needs to have arguments, which is the case for some commands shipped with oxid 6.2 