### PR TITLE
Fixed private constant REGEXP_TIMESTAMP call issue

### DIFF
--- a/src/Core/Migration/AbstractQuery.php
+++ b/src/Core/Migration/AbstractQuery.php
@@ -176,7 +176,7 @@ abstract class AbstractQuery
      */
     public static function isValidTimestamp($sTimestamp)
     {
-        return preg_match(static::REGEXP_TIMESTAMP, $sTimestamp);
+        return preg_match(self::REGEXP_TIMESTAMP, $sTimestamp);
     }
 
     /**


### PR DESCRIPTION
We are getting below error when we run **_migration:run_** console command. 

`Uncaught Error: Undefined class constant 'REGEXP_TIMESTAMP' in /vendor/oxid-professional-services/oxid-console/src/Core/Migration/AbstractQuery.php:179`

**Reason of error**: We are trying to call _REGEXP_TIMESTAMP_ private constant through static keyword. 