### PR TITLE
Fix php warnings

### DIFF
--- a/bin/oxid
+++ b/bin/oxid
@@ -10,13 +10,13 @@ function shutdown() {
         // fatal error has occured
         $trace = array_reverse($GLOBALS['dbg_stack']);
         array_pop($trace);
-        
+
         echo 'Backtrace for: \'' . $error['message'] . '\' at ' . $error['file'] . ':' . $error['line'] . ':' . "\n";
         foreach($trace as $item) {
            echo '  ' . (isset($item['file']) ? $item['file'] : '<unknown file>')
            . ':' . (isset($item['line']) ? $item['line'] : '<unknown line>')
            . ' calling ' . $item['function'] . '()' . "\n";
-        }    
+        }
     }
 }
 register_shutdown_function('shutdown');

--- a/bin/oxid
+++ b/bin/oxid
@@ -28,7 +28,6 @@ declare(ticks=1);
 //using the console is for developers
 //all errors should be shown to them
 ini_set('display_error',1);
-print "Oxid Professional Services consle  is called by $argv[0]\n";
 $binFolder = dirname($argv[0]);
 $autoloadFile = $binFolder.'/../autoload.php';
 

--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -23,7 +23,7 @@ use OxidEsales\Eshop\Core\ConfigFile;
 class Application extends BaseApplication
 {
     protected $projectRoot = '';
-   
+
     /**
      * @param string $projectRoot the root directory of the project that contains vendor and source folder
      */
@@ -79,7 +79,7 @@ class Application extends BaseApplication
         echo "commands added\n";
         parent::doRun($input, $output);
     }
-  
+
    /**
      * @param InputInterface $input
      * @param OutputInterface $output

--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -40,7 +40,10 @@ class Application extends BaseApplication
     public function doRun(InputInterface $input, OutputInterface $output)
     {
         $projectRoot = $this->projectRoot;
-        print "Oxid project root is found at $projectRoot\n";
+        $output->writeln(
+            "OXID project root is found at $projectRoot",
+            OutputInterface::VERBOSITY_VERBOSE
+        );
         chdir($projectRoot);
 
         $this->loadBootstrap($input, $output);
@@ -64,11 +67,17 @@ class Application extends BaseApplication
 
         //adding a value to avoid php warnings when oxid core try to compare that value
         $_SERVER['HTTP_HOST'] = 'localhost';
-        echo "collecting comands.. \n";
+        $output->writeln(
+            "collecting comands...",
+            OutputInterface::VERBOSITY_VERBOSE
+        );
         $commandCollector = new CommandCollector();
         $application = $this;
         $commands = $commandCollector->getAllCommands();
-        echo "commands collected\n";
+        $output->writeln(
+            "commands collected",
+            OutputInterface::VERBOSITY_VERBOSE
+        );
         foreach ($commands as $command) {
             try {
                 $application->add($command);
@@ -76,7 +85,10 @@ class Application extends BaseApplication
                 print get_class($command) . " not loadad " . $e->getMessage() . "\n" . $e->getTraceAsString();
             }
         }
-        echo "commands added\n";
+        $output->writeln(
+            "commands added",
+            OutputInterface::VERBOSITY_VERBOSE
+        );
         parent::doRun($input, $output);
     }
 
@@ -94,7 +106,10 @@ class Application extends BaseApplication
             $_GET['actshop'] = $input->getParameterOption(['--shop','-s']);
         }
 
-        print "Loading Oxid bootstrap...\n";
+        $output->writeln(
+            "Loading OXID bootstrap...",
+            OutputInterface::VERBOSITY_VERBOSE
+        );
         $possiblePathsForBootstrap = [
             $this->projectRoot . '/source/bootstrap.php',
             ];
@@ -115,7 +130,10 @@ class Application extends BaseApplication
             echo "Please specify 'BOOTSTRAP_PATH' as environmental variable to use it directly.\n";
             exit(1);
         }
-        echo "oxid bootstrap done. \n";
+        $output->writeln(
+            "OXID bootstrap done",
+            OutputInterface::VERBOSITY_VERBOSE
+        );
         return;
     }
 


### PR DESCRIPTION
closes #31 

If you think that we need them, we can add a verbose mode with multiple levels, something like:
```
vendor/bin/oxid -v # prints basic output
vendor/bin/oxid -vv # prints additional infos / notices
vendor/bin/oxid -vvv # prints debug output
```